### PR TITLE
Update EnumBehavior.php

### DIFF
--- a/Model/Behavior/EnumBehavior.php
+++ b/Model/Behavior/EnumBehavior.php
@@ -35,7 +35,7 @@ class EnumBehavior extends ModelBehavior {
 		foreach($config as $field => $values){
 			$baseRule = array(
 				/* All types to string conversion */
-				'rule' => array('inList', array_map(function($v){ return (string)$v; }, array_keys($values)), false), 
+				'rule' => array('inList', array_map(function($v){ return (string)$v; }, array_values($values)), false), 
 				'message' => __('Please choose one of the following values : %s', join(', ', $this->__translate($values))),
 				'allowEmpty' => in_array(null, $values) || in_array('', $values),
 				'required' => false


### PR DESCRIPTION
the $values array is a simple array like ('Value 1','Value 2','Value 3').  So the keys are 0,1,2 etc.  We want the values, not the keys.

Without this change, saving the Model fails validation.